### PR TITLE
Add render_regions: render each project region to its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # REAPER MCP Server
 
-A Model Context Protocol (MCP) server that enables AI agents to control REAPER DAW — 58 tools covering project management, tracks, MIDI, FX, mixing, mastering, rendering, and audio analysis.
+A Model Context Protocol (MCP) server that enables AI agents to control REAPER DAW — 59 tools covering project management, tracks, MIDI, FX, mixing, mastering, rendering, and audio analysis.
 
 ## Requirements
 
@@ -86,7 +86,7 @@ reaper-mcp-server --debug  # with debug logging
 `set_track_volume` `set_track_pan` `set_track_mute` `set_track_solo` `set_send_volume` `set_master_volume` `add_volume_automation` `add_pan_automation`
 
 ### Rendering
-`render_project` `render_stems` `render_time_selection`
+`render_project` `render_stems` `render_time_selection` `render_regions`
 
 ### Mastering
 `apply_mastering_chain` `apply_limiter` `normalize_project`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/reaper_mcp"]
 
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+# reapy warns at import when REAPER isn't running. The tests deliberately do not
+# need REAPER, so this is expected noise rather than a signal.
+filterwarnings = ["ignore::reapy.errors.DisabledDistAPIWarning"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"

--- a/src/reaper_mcp/render_tools.py
+++ b/src/reaper_mcp/render_tools.py
@@ -1,5 +1,6 @@
-import os
 import logging
+import os
+import time
 from pathlib import Path
 
 import reapy
@@ -54,6 +55,198 @@ def render_to_temp_file(sample_rate: int = 48000) -> str:
     _set_render_settings(tmp, "wav", sample_rate, 24, 2, bounds=0)
     RPR.Main_OnCommand(41824, 0)
     return tmp
+
+
+# ---------------------------------------------------------------------------
+# Region rendering
+#
+# reapy's Region/Marker classes cannot be used for enumeration in reapy 0.10:
+# Region exposes no `name` attribute, and Project.regions indexes into the
+# combined marker+region list, so regions[0] can return a marker (with
+# end == 0.0). EnumProjectMarkers2 is the reliable path.
+# ---------------------------------------------------------------------------
+
+BOUNDS_ALL_REGIONS = 3
+BOUNDS_SELECTED_REGIONS = 5
+
+RENDER_CURRENT_SETTINGS = 42230  # File: Render project, using the most recent settings
+
+
+def _get_str(key: str) -> str:
+    result = RPR.GetSetProjectInfo_String(0, key, "", False)
+    return result[3] if isinstance(result, (tuple, list)) else result
+
+
+def _set_str(key: str, value: str) -> None:
+    RPR.GetSetProjectInfo_String(0, key, value, True)
+
+
+def _parse_render_targets(raw: str, directory: str | None = None) -> list:
+    """Split REAPER's semicolon-separated RENDER_TARGETS into paths.
+
+    Region names may themselves contain ';', which would corrupt a naive split.
+    When the output directory is known, split on the ';' that immediately
+    precedes it instead, so only real separators are matched.
+    """
+    if not raw or not raw.strip():
+        return []
+    raw = raw.strip().rstrip(";")
+    if directory:
+        chunks = raw.split(";" + directory)
+        parts = [chunks[0]] + [directory + chunk for chunk in chunks[1:]]
+    else:
+        parts = raw.split(";")
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _conflicting_targets(targets: list) -> list:
+    """Targets that already exist on disk.
+
+    These matter because REAPER neither overwrites them nor reports the clash:
+    RENDER_TARGETS still names `foo.mp4` when `foo.mp4` exists, and REAPER then
+    writes `foo-001.mp4`. Left unhandled, a repeat render "succeeds" against the
+    previous run's files while the new output hides under a suffixed name.
+    """
+    return [t for t in targets if os.path.exists(t)]
+
+
+def _enum_regions() -> list:
+    """Every region as {index, start, end, length}, via EnumProjectMarkers2.
+
+    Region *names* are intentionally absent. Over reapy's distant API the name
+    out-parameter comes back unfilled at any buffer size, even though REAPER
+    resolves $region correctly server-side. Take names from RENDER_TARGETS,
+    which does carry them.
+    """
+    count = RPR.CountProjectMarkers(0, 0, 0)
+    total = count[0] if isinstance(count, (tuple, list)) else count
+    regions = []
+    for i in range(int(total)):
+        marker = RPR.EnumProjectMarkers2(0, i, 0, 0.0, 0.0, "", 0)
+        if not marker or marker[0] == 0:
+            break
+        _, _, _, is_region, position, region_end, _, number = marker
+        if is_region:
+            regions.append({"index": int(number), "start": position,
+                            "end": region_end, "length": region_end - position})
+    return regions
+
+
+def _render_in_flight(directory: str) -> bool:
+    """True while REAPER has a scratch file open in the directory.
+
+    REAPER writes each output into `<name>.sb-<hash>` and renames it on
+    completion, so the presence of one means a render is still open even if no
+    bytes happened to land during the last poll. Stalling on that would restore
+    the project's render settings underneath a running render.
+
+    Observed directly mid-render: `halicali .mp4.sb-c78f8bee-k7rct1`.
+    """
+    if not directory or not os.path.isdir(directory):
+        return False
+    for entry in os.scandir(directory):
+        try:
+            if entry.is_file() and ".sb-" in entry.name:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _directory_activity(directory: str) -> tuple:
+    """(file count, total bytes) for a directory, scratch files included.
+
+    Any byte written anywhere under the output directory changes this, which is
+    what distinguishes "still rendering" from "stopped".
+    """
+    if not directory or not os.path.isdir(directory):
+        return (0, 0)
+    count = total = 0
+    for entry in os.scandir(directory):
+        try:
+            if entry.is_file():
+                count += 1
+                total += entry.stat().st_size
+        except OSError:
+            continue
+    return (count, total)
+
+
+def _await_render(targets: list, stall_timeout: float = 120.0,
+                  timeout: float = 3600.0, poll_interval: float = 1.0,
+                  scratch_grace: float | None = None) -> tuple:
+    """Wait for a render to finish. Returns (files, status).
+
+    status is "complete", "stalled" or "timeout".
+
+    RENDER_CURRENT_SETTINGS is not reliably synchronous and REAPER exposes no
+    "am I rendering" flag, so progress has to be inferred from the filesystem.
+
+    Completion requires every expected target to exist at a stable non-zero
+    size. Waiting on the known target list, rather than globbing the directory,
+    keeps REAPER's `<name>.sb-<hash>` scratch files from being counted as
+    output and stops the gap between two regions being read as completion.
+
+    Progress, separately, is measured across the whole directory *including*
+    those scratch files, because that is where bytes land while a file is being
+    written. A render that fails, errors or is cancelled stops producing bytes,
+    so it trips stall_timeout instead of blocking for the full timeout.
+
+    Stalling is deliberately conservative, because giving up restores the
+    project's render settings: while a scratch file is present the render is
+    still open, so quiet time is tolerated up to scratch_grace (3x
+    stall_timeout by default) rather than stall_timeout.
+
+    Measured against a real aborted render (dialog closed 10s in): REAPER
+    removes its own scratch file on cancel and leaves no partial output at all,
+    since bytes go to the scratch and it is renamed only on success. So a
+    user-cancelled render is caught by stall_timeout, not scratch_grace - it
+    returned "stalled" 10.5s after the abort with stall_timeout=10, and zero
+    files. scratch_grace therefore only covers a hard crash that orphans a
+    scratch file, which is the rarer case.
+
+    The 120s default is not a guess. Measured on a full-resolution region
+    render (1728x3072 @ 50fps, 40 Mbps, 7 regions, 1.2 GB written in 117s),
+    the longest interval between writes was under 0.25s - the sampling floor,
+    i.e. bytes landed on every sample. The default is ~500x that, so a false
+    stall on a healthy render is not a realistic risk.
+    """
+    def collect():
+        return [{"path": t, "size_bytes": os.path.getsize(t)}
+                for t in targets if os.path.exists(t)]
+
+    if not targets:
+        return [], "complete"
+
+    directory = os.path.dirname(targets[0])
+    if scratch_grace is None:
+        scratch_grace = stall_timeout * 3
+    deadline = time.time() + timeout
+    last_activity = time.time()
+    activity = _directory_activity(directory)
+    previous, stable = None, 0
+
+    while time.time() < deadline:
+        current = _directory_activity(directory)
+        if current != activity:
+            activity, last_activity = current, time.time()
+
+        sizes = {t: os.path.getsize(t) for t in targets if os.path.exists(t)}
+        finished = len(sizes) == len(targets) and all(size > 0 for size in sizes.values())
+        if finished and sizes == previous:
+            stable += 1
+            if stable >= 3:
+                return collect(), "complete"
+        else:
+            stable = 0
+        previous = sizes
+
+        quiet = time.time() - last_activity
+        limit = scratch_grace if _render_in_flight(directory) else stall_timeout
+        if quiet > limit:
+            return collect(), "stalled"
+        time.sleep(poll_interval)
+    return collect(), "timeout"
 
 
 def register_tools(mcp):
@@ -181,3 +374,122 @@ def register_tools(mcp):
                 pass
             logger.error(f"render_stems failed: {e}")
             return {"success": False, "error": str(e)}
+
+    @mcp.tool()
+    def render_regions(
+        output_directory: str,
+        pattern: str = "$region",
+        selected_only: bool = False,
+        dry_run: bool = False,
+        stall_timeout_seconds: float = 120.0,
+        timeout_seconds: float = 3600.0,
+    ) -> dict:
+        """
+        Render every region in the project to its own file, named by region.
+
+        Use this for video, and for any per-region export. The other render_*
+        tools are audio-only and cannot address regions.
+
+        output_directory: where files are written.
+        pattern: filename pattern. "$region" names each file after its region;
+            $regionnumber, $project and $track are also available.
+        selected_only: render only the selected regions rather than all of them.
+        dry_run: return the regions and the exact filenames REAPER would write,
+            without rendering. Cheap — worth calling before a long render.
+
+        If any output file already exists the call fails before rendering and
+        lists the offenders. REAPER neither overwrites nor reports such a
+        clash - it writes `<name>-001.<ext>` instead - so a repeat render would
+        otherwise report success while the caller reads the previous run's
+        files. Move or delete them yourself, or render somewhere else: this
+        tool never deletes anything.
+
+        Encoding (format, resolution, bitrate) is inherited from the project's
+        own render settings, so configure those once in REAPER.
+
+        This call BLOCKS until the render finishes, which for a long project
+        can be many minutes. That is not incidental: the project's render
+        settings have to stay in place until REAPER is done with them, and are
+        restored on return. Bound the wait with stall_timeout_seconds (how long
+        with no bytes written before giving up, when REAPER has no scratch file
+        open) and timeout_seconds (the hard ceiling). The result reports status
+        "complete", "stalled" or "timeout" along with whatever was written.
+
+        REAPER shows a "Rendering to file..." progress window for the duration.
+        Closing that window cancels the render: the tool then reports status
+        "stalled" and no files, because REAPER discards its scratch file rather
+        than leaving partial output. Worth knowing if a person is at the
+        machine while an agent drives this.
+        """
+        saved_strings, saved_numbers = {}, {}
+        try:
+            output_directory = str(Path(output_directory).expanduser().resolve())
+            os.makedirs(output_directory, exist_ok=True)
+
+            for key in ("RENDER_FILE", "RENDER_PATTERN"):
+                saved_strings[key] = _get_str(key)
+            saved_numbers["RENDER_BOUNDSFLAG"] = RPR.GetSetProjectInfo(
+                0, "RENDER_BOUNDSFLAG", 0, False)
+
+            regions = _enum_regions()
+            if not regions:
+                return {"success": False,
+                        "error": "no regions are defined in the current project"}
+
+            _set_str("RENDER_FILE", output_directory)
+            _set_str("RENDER_PATTERN", pattern)
+            RPR.GetSetProjectInfo(0, "RENDER_BOUNDSFLAG", float(
+                BOUNDS_SELECTED_REGIONS if selected_only else BOUNDS_ALL_REGIONS), True)
+
+            targets = _parse_render_targets(_get_str("RENDER_TARGETS"), output_directory)
+            if not targets:
+                return {"success": False,
+                        "error": "REAPER reported no render targets; if selected_only "
+                                 "is set, check that regions are actually selected"}
+
+            clashes = _conflicting_targets(targets)
+
+            if dry_run:
+                return {"success": True, "dry_run": True,
+                        "already_exist": clashes,
+                        "output_directory": output_directory,
+                        "region_count": len(regions), "regions": regions,
+                        "would_write": targets}
+
+            if clashes:
+                return {"success": False,
+                        "error": f"{len(clashes)} output file(s) already exist. REAPER "
+                                 "would not overwrite them - it would write '<name>-001' "
+                                 "instead and still report the originals as the targets, so "
+                                 "this would look like a success against stale files. Move "
+                                 "or delete them, or render into an empty directory.",
+                        "already_exist": clashes}
+
+            started = time.time()
+            RPR.Main_OnCommand(RENDER_CURRENT_SETTINGS, 0)
+            written, status = _await_render(
+                targets, stall_timeout=stall_timeout_seconds, timeout=timeout_seconds)
+            complete = status == "complete"
+
+            result = {"success": complete,
+                       "output_directory": output_directory,
+                       "region_count": len(regions),
+                       "files_written": len(written),
+                       "files": written,
+                       "expected": targets,
+                       "complete": complete,
+                       "status": status,
+                       "elapsed_seconds": round(time.time() - started, 1)}
+            if not complete:
+                result["error"] = (
+                    f"render did not finish ({status}): wrote {len(written)} of "
+                    f"{len(targets)} expected files")
+            return result
+        except Exception as e:
+            logger.error(f"render_regions failed: {e}")
+            return {"success": False, "error": str(e)}
+        finally:
+            for key, value in saved_strings.items():
+                _set_str(key, value)
+            for key, value in saved_numbers.items():
+                RPR.GetSetProjectInfo(0, key, value, True)

--- a/src/reaper_mcp/render_tools.py
+++ b/src/reaper_mcp/render_tools.py
@@ -1,5 +1,7 @@
+import base64
 import logging
 import os
+import struct
 import time
 from pathlib import Path
 
@@ -70,6 +72,47 @@ BOUNDS_ALL_REGIONS = 3
 BOUNDS_SELECTED_REGIONS = 5
 
 RENDER_CURRENT_SETTINGS = 42230  # File: Render project, using the most recent settings
+
+# RENDER_FORMAT is a base64-encoded, encoder-specific binary blob. The layout
+# below was derived by inspecting blobs REAPER produced for known settings, and
+# only applies to the AVFoundation encoder (FOURCC 'FVAX', i.e. 'XAVF'
+# reversed). Other encoders lay their fields out differently, so every helper
+# here refuses to touch a blob whose FOURCC does not match.
+AVFOUNDATION_FOURCC = b"FVAX"
+_AVF_FIELDS = {
+    "video_bitrate_kbps": (12, "<i"),
+    "audio_bitrate_kbps": (20, "<i"),
+    "width":              (24, "<i"),
+    "height":             (28, "<i"),
+    "fps":                (32, "<f"),
+}
+
+
+def _decode_render_format(blob: str) -> dict:
+    """Best-effort decode of RENDER_FORMAT. Reports the encoder either way."""
+    raw = base64.b64decode(blob)
+    decoded = {"encoder": raw[:4].decode("ascii", "replace")}
+    if raw[:4] == AVFOUNDATION_FOURCC:
+        for name, (offset, fmt) in _AVF_FIELDS.items():
+            decoded[name] = struct.unpack_from(fmt, raw, offset)[0]
+    return decoded
+
+
+def _patch_render_format(blob: str, **fields) -> str:
+    """Return blob with the named fields replaced. Non-AVFoundation blobs raise."""
+    raw = bytearray(base64.b64decode(blob))
+    if raw[:4] != AVFOUNDATION_FOURCC:
+        raise ValueError(
+            f"render format is {bytes(raw[:4])!r}, not AVFoundation "
+            f"({AVFOUNDATION_FOURCC!r}); its byte layout is different, so these "
+            "settings cannot be applied. Configure them in REAPER instead."
+        )
+    for name, value in fields.items():
+        if value is None:
+            continue
+        offset, fmt = _AVF_FIELDS[name]
+        struct.pack_into(fmt, raw, offset, float(value) if fmt == "<f" else int(value))
+    return base64.b64encode(bytes(raw)).decode()
 
 
 def _get_str(key: str) -> str:
@@ -381,6 +424,11 @@ def register_tools(mcp):
         pattern: str = "$region",
         selected_only: bool = False,
         dry_run: bool = False,
+        video_bitrate_kbps: int | None = None,
+        audio_bitrate_kbps: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        fps: float | None = None,
         stall_timeout_seconds: float = 120.0,
         timeout_seconds: float = 3600.0,
     ) -> dict:
@@ -404,8 +452,10 @@ def register_tools(mcp):
         files. Move or delete them yourself, or render somewhere else: this
         tool never deletes anything.
 
-        Encoding (format, resolution, bitrate) is inherited from the project's
-        own render settings, so configure those once in REAPER.
+        Encoding is inherited from the project's own render settings unless
+        overridden. The optional video_bitrate_kbps, audio_bitrate_kbps, width,
+        height and fps arguments require REAPER's AVFoundation encoder and fail
+        cleanly on any other; omitting them is the recommended path.
 
         This call BLOCKS until the render finishes, which for a long project
         can be many minutes. That is not incidental: the project's render
@@ -426,7 +476,7 @@ def register_tools(mcp):
             output_directory = str(Path(output_directory).expanduser().resolve())
             os.makedirs(output_directory, exist_ok=True)
 
-            for key in ("RENDER_FILE", "RENDER_PATTERN"):
+            for key in ("RENDER_FILE", "RENDER_PATTERN", "RENDER_FORMAT"):
                 saved_strings[key] = _get_str(key)
             saved_numbers["RENDER_BOUNDSFLAG"] = RPR.GetSetProjectInfo(
                 0, "RENDER_BOUNDSFLAG", 0, False)
@@ -435,6 +485,16 @@ def register_tools(mcp):
             if not regions:
                 return {"success": False,
                         "error": "no regions are defined in the current project"}
+
+            overrides = {"video_bitrate_kbps": video_bitrate_kbps,
+                         "audio_bitrate_kbps": audio_bitrate_kbps,
+                         "width": width, "height": height, "fps": fps}
+            if any(value is not None for value in overrides.values()):
+                try:
+                    _set_str("RENDER_FORMAT",
+                             _patch_render_format(saved_strings["RENDER_FORMAT"], **overrides))
+                except ValueError as e:
+                    return {"success": False, "error": str(e)}
 
             _set_str("RENDER_FILE", output_directory)
             _set_str("RENDER_PATTERN", pattern)
@@ -454,8 +514,10 @@ def register_tools(mcp):
                         "already_exist": clashes,
                         "output_directory": output_directory,
                         "region_count": len(regions), "regions": regions,
-                        "would_write": targets}
+                        "would_write": targets,
+                        "settings": _decode_render_format(_get_str("RENDER_FORMAT"))}
 
+            settings = _decode_render_format(_get_str("RENDER_FORMAT"))
             if clashes:
                 return {"success": False,
                         "error": f"{len(clashes)} output file(s) already exist. REAPER "
@@ -479,6 +541,7 @@ def register_tools(mcp):
                        "expected": targets,
                        "complete": complete,
                        "status": status,
+                       "settings": settings,
                        "elapsed_seconds": round(time.time() - started, 1)}
             if not complete:
                 result["error"] = (

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -1,0 +1,161 @@
+"""Unit tests for render_regions' pure helpers.
+
+Deliberately no REAPER: these cover the parsing that has no business talking to
+a DAW, and that is where the subtle breakage lives. The tool functions
+themselves need a live REAPER and are not covered here.
+"""
+import threading
+import time
+
+from reaper_mcp.render_tools import (
+    _await_render,
+    _conflicting_targets,
+    _parse_render_targets,
+)
+
+
+class TestParseRenderTargets:
+    def test_splits_on_semicolons(self):
+        raw = "/out/a.mp4;/out/b.mp4;/out/c.mp4"
+        assert _parse_render_targets(raw, "/out") == ["/out/a.mp4", "/out/b.mp4", "/out/c.mp4"]
+
+    def test_tolerates_trailing_semicolon(self):
+        # REAPER emits a trailing separator
+        assert _parse_render_targets("/out/a.mp4;/out/b.mp4;", "/out") == [
+            "/out/a.mp4", "/out/b.mp4"]
+
+    def test_region_name_containing_a_semicolon_survives(self):
+        # the reason this function exists rather than a plain str.split(";")
+        raw = "/out/intro; the reprise.mp4;/out/outro.mp4"
+        assert _parse_render_targets(raw, "/out") == [
+            "/out/intro; the reprise.mp4", "/out/outro.mp4"]
+
+    def test_single_target(self):
+        assert _parse_render_targets("/out/only.mp4", "/out") == ["/out/only.mp4"]
+
+    def test_empty_and_blank(self):
+        assert _parse_render_targets("", "/out") == []
+        assert _parse_render_targets("   ", "/out") == []
+        assert _parse_render_targets(None, "/out") == []
+
+    def test_without_directory_falls_back_to_naive_split(self):
+        assert _parse_render_targets("a.mp4;b.mp4") == ["a.mp4", "b.mp4"]
+
+
+FAST = {"poll_interval": 0.02, "timeout": 5.0}
+
+
+class TestAwaitRender:
+    """Completion and stall detection. Filesystem and clock only - no REAPER."""
+
+    def test_completes_when_every_target_is_present(self, tmp_path):
+        targets = [str(tmp_path / f"{i}.mp4") for i in range(3)]
+        for target in targets:
+            with open(target, "wb") as handle:
+                handle.write(b"x" * 32)
+        written, status = _await_render(targets, stall_timeout=2.0, **FAST)
+        assert status == "complete"
+        assert len(written) == 3
+        assert all(f["size_bytes"] == 32 for f in written)
+
+    def test_stalls_when_a_target_never_appears(self, tmp_path):
+        # a render that dies partway leaves some files and then stops writing
+        targets = [str(tmp_path / "done.mp4"), str(tmp_path / "never.mp4")]
+        with open(targets[0], "wb") as handle:
+            handle.write(b"x" * 32)
+        started = time.time()
+        written, status = _await_render(targets, stall_timeout=0.3, **FAST)
+        assert status == "stalled"
+        assert len(written) == 1          # partial progress is still reported
+        assert time.time() - started < 3.0  # gave up early, did not run to timeout
+
+    def test_stalls_on_a_zero_byte_target(self, tmp_path):
+        # REAPER creates the output file before writing to it; 0 bytes is not done
+        target = str(tmp_path / "empty.mp4")
+        with open(target, "wb"):
+            pass
+        _, status = _await_render([target], stall_timeout=0.3, **FAST)
+        assert status == "stalled"
+
+    def test_growing_scratch_file_prevents_a_premature_stall(self, tmp_path):
+        # REAPER writes into <name>.sb-<hash> before the final file appears, so
+        # that growth must count as progress or long renders get cut off
+        target = tmp_path / "out.mp4"
+        scratch = tmp_path / "out.mp4.sb-deadbeef"
+
+        def render():
+            deadline = time.time() + 1.0      # keep busy well past stall_timeout
+            while time.time() < deadline:
+                with open(scratch, "ab") as handle:
+                    handle.write(b"x" * 4096)
+                time.sleep(0.02)
+            scratch.unlink()
+            with open(target, "wb") as handle:
+                handle.write(b"y" * 128)
+
+        worker = threading.Thread(target=render)
+        worker.start()
+        try:
+            written, status = _await_render([str(target)], stall_timeout=0.3, **FAST)
+        finally:
+            worker.join()
+        assert status == "complete"
+        assert len(written) == 1
+
+    def test_reports_timeout_separately_from_stall(self, tmp_path):
+        target = str(tmp_path / "never.mp4")
+        written, status = _await_render(
+            [target], stall_timeout=60.0, timeout=0.2, poll_interval=0.02)
+        assert status == "timeout"
+        assert written == []
+
+    def test_no_targets_is_trivially_complete(self):
+        assert _await_render([]) == ([], "complete")
+
+    def test_open_scratch_file_defers_the_stall(self, tmp_path):
+        # a scratch file means REAPER still has the render open; giving up would
+        # restore the project's render settings underneath it
+        scratch = tmp_path / "out.mp4.sb-deadbeef"
+        with open(scratch, "wb") as handle:
+            handle.write(b"x" * 64)
+        target = str(tmp_path / "out.mp4")
+        started = time.time()
+        _, status = _await_render([target], stall_timeout=0.2, scratch_grace=30.0,
+                                  timeout=1.0, poll_interval=0.02)
+        # ran to the hard timeout instead of stalling at 0.2s
+        assert status == "timeout"
+        assert time.time() - started >= 0.9
+
+    def test_orphaned_scratch_file_still_stalls_eventually(self, tmp_path):
+        # ...but a dead render that left a scratch behind must not hang forever
+        scratch = tmp_path / "out.mp4.sb-deadbeef"
+        with open(scratch, "wb") as handle:
+            handle.write(b"x" * 64)
+        target = str(tmp_path / "out.mp4")
+        started = time.time()
+        _, status = _await_render([target], stall_timeout=0.2, scratch_grace=0.6,
+                                  timeout=30.0, poll_interval=0.02)
+        assert status == "stalled"
+        assert time.time() - started < 5.0
+
+
+class TestConflictingTargets:
+    """REAPER neither overwrites nor reports a clash - it writes <name>-001."""
+
+    def test_none_when_directory_is_empty(self, tmp_path):
+        targets = [str(tmp_path / f"{i}.mp4") for i in range(3)]
+        assert _conflicting_targets(targets) == []
+
+    def test_reports_only_the_files_that_exist(self, tmp_path):
+        targets = [str(tmp_path / f"{i}.mp4") for i in range(3)]
+        for i in (0, 2):
+            with open(targets[i], "wb") as handle:
+                handle.write(b"x")
+        assert _conflicting_targets(targets) == [targets[0], targets[2]]
+
+    def test_preserves_target_order(self, tmp_path):
+        targets = [str(tmp_path / n) for n in ("c.mp4", "a.mp4", "b.mp4")]
+        for t in targets:
+            with open(t, "wb") as handle:
+                handle.write(b"x")
+        assert _conflicting_targets(targets) == targets

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -1,17 +1,36 @@
 """Unit tests for render_regions' pure helpers.
 
-Deliberately no REAPER: these cover the parsing that has no business talking to
-a DAW, and that is where the subtle breakage lives. The tool functions
-themselves need a live REAPER and are not covered here.
+Deliberately no REAPER: these cover the parsing and byte-packing that has no
+business talking to a DAW, and that is where the subtle breakage lives. The
+tool functions themselves need a live REAPER and are not covered here.
 """
+import base64
+import struct
 import threading
 import time
 
+import pytest
+
 from reaper_mcp.render_tools import (
+    _AVF_FIELDS,
+    AVFOUNDATION_FOURCC,
     _await_render,
     _conflicting_targets,
+    _decode_render_format,
     _parse_render_targets,
+    _patch_render_format,
 )
+
+BLOB_LEN = 46
+
+
+def make_blob(fourcc: bytes = AVFOUNDATION_FOURCC, **fields) -> str:
+    raw = bytearray(BLOB_LEN)
+    raw[0:4] = fourcc
+    for name, (offset, fmt) in _AVF_FIELDS.items():
+        value = fields.get(name, 0)
+        struct.pack_into(fmt, raw, offset, float(value) if fmt == "<f" else int(value))
+    return base64.b64encode(bytes(raw)).decode()
 
 
 class TestParseRenderTargets:
@@ -40,6 +59,55 @@ class TestParseRenderTargets:
 
     def test_without_directory_falls_back_to_naive_split(self):
         assert _parse_render_targets("a.mp4;b.mp4") == ["a.mp4", "b.mp4"]
+
+
+class TestRenderFormat:
+    def test_round_trips_every_field(self):
+        blob = make_blob(video_bitrate_kbps=40000, audio_bitrate_kbps=256,
+                         width=1728, height=3072, fps=50.0)
+        decoded = _decode_render_format(blob)
+        assert decoded["encoder"] == "FVAX"
+        assert decoded["video_bitrate_kbps"] == 40000
+        assert decoded["audio_bitrate_kbps"] == 256
+        assert decoded["width"] == 1728
+        assert decoded["height"] == 3072
+        assert decoded["fps"] == pytest.approx(50.0)
+
+    def test_patch_replaces_only_named_fields(self):
+        blob = make_blob(video_bitrate_kbps=40000, width=1728, height=3072, fps=50.0)
+        patched = _decode_render_format(_patch_render_format(blob, width=1080))
+        assert patched["width"] == 1080
+        assert patched["height"] == 3072          # untouched
+        assert patched["video_bitrate_kbps"] == 40000
+
+    def test_none_values_are_ignored(self):
+        blob = make_blob(width=1728, height=3072)
+        patched = _decode_render_format(_patch_render_format(blob, width=None, height=None))
+        assert patched["width"] == 1728
+        assert patched["height"] == 3072
+
+    def test_fps_is_stored_as_float_not_int(self):
+        blob = _patch_render_format(make_blob(), fps=29.97)
+        assert _decode_render_format(blob)["fps"] == pytest.approx(29.97, rel=1e-6)
+
+    def test_patch_preserves_unknown_bytes(self):
+        # two fields in the layout are unidentified; they must survive a patch
+        raw = bytearray(base64.b64decode(make_blob(width=1728)))
+        struct.pack_into("<i", raw, 36, 1)
+        struct.pack_into("<i", raw, 40, 95)
+        patched = base64.b64decode(_patch_render_format(
+            base64.b64encode(bytes(raw)).decode(), width=1080))
+        assert struct.unpack_from("<i", patched, 36)[0] == 1
+        assert struct.unpack_from("<i", patched, 40)[0] == 95
+
+    def test_patch_refuses_a_foreign_encoder(self):
+        with pytest.raises(ValueError, match="not AVFoundation"):
+            _patch_render_format(make_blob(fourcc=b"PMFF"), width=1080)
+
+    def test_decode_reports_foreign_encoder_without_raising(self):
+        decoded = _decode_render_format(make_blob(fourcc=b"PMFF"))
+        assert decoded["encoder"] == "PMFF"
+        assert "width" not in decoded
 
 
 FAST = {"poll_interval": 0.02, "timeout": 5.0}


### PR DESCRIPTION
## What this adds

`render_regions` — renders every region in the project to its own file, named by region.

The existing `render_*` tools are audio-only (wav/flac/mp3/ogg) and have no region bounds, so there was no way to export one file per region. That's the common case for video, and for batch clip export generally. `render_time_selection` is the nearest thing and takes raw seconds, so callers end up driving region boundaries by hand and getting `.wav` back regardless.

```python
render_regions(output_directory, pattern="$region", selected_only=False, dry_run=False,
               stall_timeout_seconds=120.0, timeout_seconds=3600.0)
```

It sets `RENDER_BOUNDSFLAG` to 3 (all regions) or 5 (selected), applies the filename pattern, and triggers action 42230. **Encoding is inherited from the project's own render settings** — the tool deliberately stays out of the encoder's business, so video works by configuring REAPER once. Everything it changes is restored in a `finally`. `dry_run` returns the regions and the exact output paths for free.

## Four REAPER/reapy behaviours it has to work around

All verified against a running REAPER (7.73, macOS) rather than assumed:

1. **reapy's `Region`/`Marker` classes are unusable for enumeration in 0.10.** `Region` exposes no `name` attribute, and `Project.regions` indexes into the *combined* marker+region list — so `regions[0]` can hand back a marker, with `end == 0.0`. This uses `EnumProjectMarkers2` directly.

2. **Region names can't be read back over the distant API.** `EnumProjectMarkers2`'s name out-parameter comes back unfilled at any buffer size. REAPER still resolves `$region` correctly server-side, so names are taken from `RENDER_TARGETS` — which doubles as the dry run.

3. **Existing outputs are neither overwritten nor reported.** `RENDER_TARGETS` still names `foo.mp4` when `foo.mp4` exists, and REAPER writes `foo-001.mp4` instead. Waiting on `RENDER_TARGETS` would therefore see the *previous* run's file, report success, and leave the new output under a name the caller never hears about. Clashes are detected up front and the call fails listing them. **The tool never deletes anything** — clearing the directory is the caller's decision, not an agent's.

4. **Action 42230 isn't reliably synchronous**, and REAPER exposes no "am I rendering" flag. Progress is inferred from the filesystem — notably *without* talking to REAPER during the wait, since its distant API goes unresponsive while rendering.

## Completion detection

Completion needs every expected target at a stable non-zero size. Waiting on the known target list rather than globbing keeps REAPER's `<name>.sb-<hash>` scratch files from being counted as output.

Giving up restores the project's render settings, so it must not happen under a running render: while a scratch file is open, quiet time is tolerated up to `scratch_grace` (3× `stall_timeout`). Both bounds are measured, not guessed:

- **Full-resolution render** (1728×3072 @ 50fps, 40 Mbps, 7 regions, 1.2 GB in 117s): the longest gap between writes was under **0.25s** — the sampling floor. The 120s default is ~500× that.
- **Real aborted render** (progress dialog closed 10s in): REAPER removes its own scratch file and leaves no partial output, so an abort is caught by `stall_timeout`, not `scratch_grace` — `"stalled"` 10.5s after the abort with `stall_timeout=10`, zero files. `scratch_grace` therefore only covers a crash that orphans a scratch file.

## Tests

These are the repo's first tests, so this also wires up pytest (`pythonpath = ["src"]`, `testpaths = ["tests"]`) — a bare `pytest` works after `pip install -e '.[dev]'`. **They need no REAPER**; only the pure helpers are covered, and the module docstring says so rather than implying broader coverage.

24 tests over `RENDER_TARGETS` parsing (including a region name containing `;`, which a naive split corrupts), the `RENDER_FORMAT` byte packing, completion/stall/timeout detection, and clash detection. Verified by mutation — reverting the semicolon handling, dropping the FOURCC guard, packing fps as int, removing stall detection, and removing scratch-awareness each fail exactly the intended test.

## The two commits

Commit 2 is **self-contained and droppable** — it carries its own tests, and reverting it leaves 17 passing tests and clean lint. Happy to drop it if the byte-level approach isn't welcome; `render_regions` works fully without it.

## Known limitations, stated rather than implied

- **The call blocks for the render's duration.** That's structural: the render settings must stay in place until REAPER is done. `stall_timeout_seconds` and `timeout_seconds` bound it, and the result reports `"complete"`, `"stalled"` or `"timeout"` with whatever was written. A real 70s render over MCP completes fine; a genuine async mode would need a job API, which felt like a larger design change than this PR should smuggle in.
- **Single environment.** Everything above was observed on macOS with REAPER 7.73 and the AVFoundation encoder, on one project. The `.sb-` scratch convention, the `-001` rename, and the `"Rendering to file..."` dialog name are observed behaviours, not documented contracts — they may differ on Windows. Where they do, the code degrades safely (`_render_in_flight` returns `False` and the plain `stall_timeout` governs) rather than misbehaving.
- **Region names aren't exposed** in the returned region list, for the distant-API reason above. The output filenames carry them.

Ruff is unchanged at the existing baseline for `render_tools.py`, and clean for the new test file.
